### PR TITLE
fix(network): disable systemd-resolved DNS stub listener

### DIFF
--- a/services/network.nix
+++ b/services/network.nix
@@ -33,6 +33,9 @@
   services.resolved = {
     enable = true;
     dnssec = "allow-downgrade";
+    extraConfig = ''
+      DNSStubListener=no
+    '';
   };
 
   # Use systemd-networkd for network management


### PR DESCRIPTION
Frees port 53 for AdGuard Home; resolved was winning the race on boot.